### PR TITLE
Fix basestring check to work with both 2.x and 3

### DIFF
--- a/tornalet.py
+++ b/tornalet.py
@@ -57,6 +57,12 @@ def asyncify(func = None, callback_argname = None):
         Just use it normally, tornalet won't do anything.
 
     """
+    try:
+        basestring
+    except NameError:
+        # Python 3 removed basestring, all strings inherit unicode now
+        basestring = unicode
+
     if isinstance(func, basestring) or func is None:
         callback_argname = func
         func = None


### PR DESCRIPTION
basestring was removed in Python 3 and all strings now inherit from unicode, I've added a workaround to set basestring to unicode if it's not available.
